### PR TITLE
Replace log.info calls with log.debug to reduce clutter in client logs

### DIFF
--- a/src/main/java/com/herblorerecipes/cache/TooltipCache.java
+++ b/src/main/java/com/herblorerecipes/cache/TooltipCache.java
@@ -132,7 +132,7 @@ public class TooltipCache
 			}
 		});
 		long nanos = timer.stop().elapsed().toNanos();
-		log.info("Tooltip cache was loaded in {}ms.", nanos / 1000000.0);
+		log.debug("Tooltip cache was loaded in {}ms.", nanos / 1000000.0);
 	}
 
 	public boolean contains(int id)


### PR DESCRIPTION
Fixes #22 

This logging may be worth removing entirely but swapping to log.debug at least removes the clutter we see in logs in #support.