### PR TITLE
null safety & safely catch potential NPE

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @climbridecode

--- a/src/main/java/com/herblorerecipes/cache/TooltipCache.java
+++ b/src/main/java/com/herblorerecipes/cache/TooltipCache.java
@@ -137,7 +137,18 @@ public class TooltipCache
 
 	public boolean contains(int id)
 	{
-		return this.tooltipCache.containsKey(id);
+		if (this.tooltipCache != null)
+		{
+			try
+			{
+				return this.tooltipCache.containsKey(id);
+			}
+			catch (NullPointerException e)
+			{
+				log.debug("NPE thrown, id: {}. e: {}", id, e);
+			}
+		}
+		return false;
 	}
 
 	public Tooltip get(int id)


### PR DESCRIPTION
Hopefully closes https://github.com/climbridecode/herblore-recipes/issues/21. Haven't been able to reproduce this bug yet but the `containsKey` can potentially throw an NPE and also sanity checking that the map is not `null` before calling `containsKey` on it.