### PR TITLE
Fix broken tooltips and add missing recipes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,3 +30,9 @@ tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
     options.release.set(11)
 }
+
+tasks.register('run', JavaExec) {
+    classpath = sourceSets.test.runtimeClasspath
+    mainClass = 'com.herblorerecipes.HerbloreRecipesPluginTest'
+    jvmArgs = ['-ea']
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/herblorerecipes/HerbloreRecipesOverlay.java
+++ b/src/main/java/com/herblorerecipes/HerbloreRecipesOverlay.java
@@ -7,12 +7,8 @@ import java.awt.Graphics2D;
 import java.awt.event.KeyEvent;
 import javax.inject.Inject;
 import net.runelite.api.Client;
-import net.runelite.api.InventoryID;
-import net.runelite.api.Item;
-import net.runelite.api.ItemContainer;
 import net.runelite.api.MenuAction;
 import net.runelite.api.MenuEntry;
-import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.InterfaceID;
 import net.runelite.api.widgets.WidgetUtil;
 import net.runelite.client.config.Keybind;
@@ -26,12 +22,6 @@ import org.apache.commons.lang3.StringUtils;
 public class HerbloreRecipesOverlay extends Overlay implements KeyListener
 {
 
-	private static final int INVENTORY_ITEM_WIDGETID = ComponentID.INVENTORY_CONTAINER;
-	private static final int BANK_ITEM_WIDGETID = ComponentID.BANK_ITEM_CONTAINER;
-	private static final int BANKED_INVENTORY_ITEM_WIDGETID = ComponentID.BANK_INVENTORY_ITEM_CONTAINER;
-	private static final int SEED_VAULT_INVENTORY_WIDGETID = ComponentID.SEED_VAULT_INVENTORY_ITEM_CONTAINER;
-	private static final int SEED_VAULT_WIDGETID = ComponentID.SEED_VAULT_ITEM_CONTAINER;
-	private static final int GROUP_STORAGE_ITEM_WIDGETID = ComponentID.GROUP_STORAGE_ITEM_CONTAINER;
 	public final TooltipCache tooltipCache;
 	private final Client client;
 	private final TooltipManager tooltipManager;
@@ -122,13 +112,12 @@ public class HerbloreRecipesOverlay extends Overlay implements KeyListener
 			case WIDGET_TARGET_ON_WIDGET:
 			case WIDGET_TARGET:
 			case CC_OP:
-			case ITEM_USE:
-			case ITEM_FIRST_OPTION:
-			case ITEM_SECOND_OPTION:
-			case ITEM_THIRD_OPTION:
-			case ITEM_FOURTH_OPTION:
+			case WIDGET_FIRST_OPTION:
+			case WIDGET_SECOND_OPTION:
+			case WIDGET_THIRD_OPTION:
+			case WIDGET_FOURTH_OPTION:
 			case CC_OP_LOW_PRIORITY:
-			case ITEM_FIFTH_OPTION:
+			case WIDGET_FIFTH_OPTION:
 				switch (groupId)
 				{
 					case InterfaceID.GROUP_STORAGE_INVENTORY:
@@ -179,7 +168,7 @@ public class HerbloreRecipesOverlay extends Overlay implements KeyListener
 
 	private void showTooltip(int widgetId, MenuEntry menuEntry)
 	{
-		int itemId = getItemIdFromWidgetId(widgetId, menuEntry);
+		int itemId = getItemIdFromMenuEntry(menuEntry);
 
 		if (Potions.isSeed(itemId) && !config.showTooltipOnPrimarySeeds())
 		{
@@ -199,22 +188,15 @@ public class HerbloreRecipesOverlay extends Overlay implements KeyListener
 		showTooltip(itemId);
 	}
 
-	private int getItemIdFromWidgetId(int widgetId, MenuEntry menuEntry)
+	private int getItemIdFromMenuEntry(MenuEntry menuEntry)
 	{
-		ItemContainer container = getContainer(widgetId);
-		if (container == null)
+		int itemId = menuEntry.getItemId();
+		if (itemId < 0)
 		{
 			return -1;
 		}
 
-
-		Item item = container.getItem(menuEntry.getParam0());
-		if (item == null)
-		{
-			return -1;
-		}
-
-		return itemManager.canonicalize(item.getId());
+		return itemManager.canonicalize(itemId);
 	}
 
 	private void showTooltip(int itemId)
@@ -225,26 +207,6 @@ public class HerbloreRecipesOverlay extends Overlay implements KeyListener
 		}
 	}
 
-	private ItemContainer getContainer(int widgetId)
-	{
-		if (widgetId == INVENTORY_ITEM_WIDGETID || widgetId == BANKED_INVENTORY_ITEM_WIDGETID || widgetId == SEED_VAULT_INVENTORY_WIDGETID)
-		{
-			return client.getItemContainer(InventoryID.INVENTORY);
-		}
-		else if (widgetId == BANK_ITEM_WIDGETID)
-		{
-			return client.getItemContainer(InventoryID.BANK);
-		}
-		else if (widgetId == SEED_VAULT_WIDGETID)
-		{
-			return client.getItemContainer(InventoryID.SEED_VAULT);
-		}
-		else if (widgetId == GROUP_STORAGE_ITEM_WIDGETID)
-		{
-			return client.getItemContainer(InventoryID.GROUP_STORAGE);
-		}
-		return null;
-	}
 
 	@Override
 	public void keyTyped(KeyEvent e)

--- a/src/main/java/com/herblorerecipes/model/Potions.java
+++ b/src/main/java/com/herblorerecipes/model/Potions.java
@@ -745,6 +745,325 @@ public enum Potions
 		.grimyHerb(ItemID.GRIMY_IRIT_LEAF)
 		.secondaries(ImmutableSet.of(ItemID.SWAMP_TAR))
 		.ids(ImmutableSet.of(ItemID.IRIT_TAR))
+		.build()),
+
+	// NEW POTIONS (2025)
+	SURGE_POTION(Potion.builder()
+		.level(81)
+		.name("Surge potion")
+		.basicBase(ItemID.VIAL_OF_WATER)
+		.primary(ItemID.TORSTOL)
+		.grimyHerb(ItemID.GRIMY_TORSTOL)
+		.primarySeed(ItemID.TORSTOL_SEED)
+		.secondaries(ImmutableSet.of(ItemID.DEMONIC_TALLOW))
+		.unfinishedPotion(ItemID.TORSTOL_POTION_UNF)
+		.ids(ImmutableSet.of(ItemID.SURGE_POTION1, ItemID.SURGE_POTION2, ItemID.SURGE_POTION3, ItemID.SURGE_POTION4))
+		.build()),
+
+	// SAILING POTIONS
+	HAEMOSTATIC_POULTICE(Potion.builder()
+		.level(56)
+		.name("Haemostatic poultice")
+		.basicBase(ItemID.VIAL_OF_WATER)
+		.primary(ItemID.ELKHORN_CORAL)
+		.secondaries(ImmutableSet.of(ItemID.SQUID_PASTE))
+		.unfinishedPotion(ItemID.ELKHORN_POTION_UNF)
+		.ids(ImmutableSet.of(ItemID.HAEMOSTATIC_POULTICE))
+		.build()),
+
+	HAEMOSTATIC_DRESSING(Potion.builder()
+		.level(56)
+		.name("Haemostatic dressing")
+		.complexBase(ImmutableSet.of(HAEMOSTATIC_POULTICE.potion))
+		.secondaries(ImmutableSet.of(ItemID.COTTON_YARN))
+		.ids(ImmutableSet.of(ItemID.HAEMOSTATIC_DRESSING_1, ItemID.HAEMOSTATIC_DRESSING_2, ItemID.HAEMOSTATIC_DRESSING_3, ItemID.HAEMOSTATIC_DRESSING_4))
+		.build()),
+
+	SUPER_FISHING_POTION(Potion.builder()
+		.level(62)
+		.name("Super fishing potion")
+		.basicBase(ItemID.VIAL_OF_WATER)
+		.primary(ItemID.PILLAR_CORAL)
+		.secondaries(ImmutableSet.of(ItemID.HADDOCK_EYE))
+		.unfinishedPotion(ItemID.PILLAR_POTION_UNF)
+		.ids(ImmutableSet.of(ItemID.SUPER_FISHING_POTION1, ItemID.SUPER_FISHING_POTION2, ItemID.SUPER_FISHING_POTION3, ItemID.SUPER_FISHING_POTION4))
+		.build()),
+
+	EXTREME_ENERGY_POTION(Potion.builder()
+		.level(66)
+		.name("Extreme energy potion")
+		.complexBase(ImmutableSet.of(SUPER_ENERGY.potion))
+		.secondaries(ImmutableSet.of(ItemID.YELLOW_FIN))
+		.ids(ImmutableSet.of(ItemID.EXTREME_ENERGY_POTION1, ItemID.EXTREME_ENERGY_POTION2, ItemID.EXTREME_ENERGY_POTION3, ItemID.EXTREME_ENERGY_POTION4))
+		.build()),
+
+	SUPER_HUNTER_POTION(Potion.builder()
+		.level(67)
+		.name("Super hunter potion")
+		.basicBase(ItemID.VIAL_OF_WATER)
+		.primary(ItemID.PILLAR_CORAL)
+		.secondaries(ImmutableSet.of(ItemID.CRAB_PASTE))
+		.unfinishedPotion(ItemID.PILLAR_POTION_UNF)
+		.ids(ImmutableSet.of(ItemID.SUPER_HUNTER_POTION1, ItemID.SUPER_HUNTER_POTION2, ItemID.SUPER_HUNTER_POTION3, ItemID.SUPER_HUNTER_POTION4))
+		.build()),
+
+	EXTENDED_STAMINA_POTION(Potion.builder()
+		.level(85)
+		.name("Extended stamina potion")
+		.complexBase(ImmutableSet.of(STAMINA_POTION.potion))
+		.secondaries(ImmutableSet.of(ItemID.MARLIN_SCALES))
+		.ids(ImmutableSet.of(ItemID.EXTENDED_STAMINA_POTION1, ItemID.EXTENDED_STAMINA_POTION2, ItemID.EXTENDED_STAMINA_POTION3, ItemID.EXTENDED_STAMINA_POTION4))
+		.build()),
+
+	ARMADYL_BREW(Potion.builder()
+		.level(89)
+		.name("Armadyl brew")
+		.basicBase(ItemID.VIAL_OF_WATER)
+		.primary(ItemID.UMBRAL_CORAL)
+		.secondaries(ImmutableSet.of(ItemID.RAINBOW_CRAB_PASTE))
+		.unfinishedPotion(ItemID.UMBRAL_POTION_UNF)
+		.ids(ImmutableSet.of(ItemID.ARMADYL_BREW1, ItemID.ARMADYL_BREW2, ItemID.ARMADYL_BREW3, ItemID.ARMADYL_BREW4))
+		.build()),
+
+	ANTI_ODOUR_SALT(Potion.builder()
+		.level(49)
+		.name("Anti-odour salt")
+		.primary(ItemID.ELKHORN_CORAL)
+		.secondaries(ImmutableSet.of(ItemID.CRAB_PASTE))
+		.ids(ImmutableSet.of(ItemID.ANTIODOUR_SALT))
+		.build()),
+
+	// BARBARIAN MIXES
+	ATTACK_MIX(Potion.builder()
+		.level(4)
+		.name("Attack mix")
+		.complexBase(ImmutableSet.of(ATTACK_POTION.potion))
+		.secondaries(ImmutableSet.of(ItemID.ROE))
+		.ids(ImmutableSet.of(ItemID.ATTACK_MIX1, ItemID.ATTACK_MIX2))
+		.build()),
+
+	ANTIPOISON_MIX(Potion.builder()
+		.level(6)
+		.name("Antipoison mix")
+		.complexBase(ImmutableSet.of(ANTIPOISON.potion))
+		.secondaries(ImmutableSet.of(ItemID.ROE))
+		.ids(ImmutableSet.of(ItemID.ANTIPOISON_MIX1, ItemID.ANTIPOISON_MIX2))
+		.build()),
+
+	RELICYMS_MIX(Potion.builder()
+		.level(9)
+		.name("Relicym's mix")
+		.complexBase(ImmutableSet.of(RELICYMS_BALM.potion))
+		.secondaries(ImmutableSet.of(ItemID.ROE))
+		.ids(ImmutableSet.of(ItemID.RELICYMS_MIX1, ItemID.RELICYMS_MIX2))
+		.build()),
+
+	STRENGTH_MIX(Potion.builder()
+		.level(14)
+		.name("Strength mix")
+		.complexBase(ImmutableSet.of(STRENGTH_POTION.potion))
+		.secondaries(ImmutableSet.of(ItemID.ROE))
+		.ids(ImmutableSet.of(ItemID.STRENGTH_MIX1, ItemID.STRENGTH_MIX2))
+		.build()),
+
+	RESTORE_MIX(Potion.builder()
+		.level(24)
+		.name("Restore mix")
+		.complexBase(ImmutableSet.of(RESTORE_POTION.potion))
+		.secondaries(ImmutableSet.of(ItemID.ROE))
+		.ids(ImmutableSet.of(ItemID.RESTORE_MIX1, ItemID.RESTORE_MIX2))
+		.build()),
+
+	ENERGY_MIX(Potion.builder()
+		.level(29)
+		.name("Energy mix")
+		.complexBase(ImmutableSet.of(ENERGY_POTION.potion))
+		.secondaries(ImmutableSet.of(ItemID.CAVIAR))
+		.ids(ImmutableSet.of(ItemID.ENERGY_MIX1, ItemID.ENERGY_MIX2))
+		.build()),
+
+	DEFENCE_MIX(Potion.builder()
+		.level(33)
+		.name("Defence mix")
+		.complexBase(ImmutableSet.of(DEFENCE_POTION.potion))
+		.secondaries(ImmutableSet.of(ItemID.CAVIAR))
+		.ids(ImmutableSet.of(ItemID.DEFENCE_MIX1, ItemID.DEFENCE_MIX2))
+		.build()),
+
+	AGILITY_MIX(Potion.builder()
+		.level(37)
+		.name("Agility mix")
+		.complexBase(ImmutableSet.of(AGILITY_POTION.potion))
+		.secondaries(ImmutableSet.of(ItemID.CAVIAR))
+		.ids(ImmutableSet.of(ItemID.AGILITY_MIX1, ItemID.AGILITY_MIX2))
+		.build()),
+
+	COMBAT_MIX(Potion.builder()
+		.level(40)
+		.name("Combat mix")
+		.complexBase(ImmutableSet.of(COMBAT_POTION.potion))
+		.secondaries(ImmutableSet.of(ItemID.CAVIAR))
+		.ids(ImmutableSet.of(ItemID.COMBAT_MIX1, ItemID.COMBAT_MIX2))
+		.build()),
+
+	PRAYER_MIX(Potion.builder()
+		.level(42)
+		.name("Prayer mix")
+		.complexBase(ImmutableSet.of(PRAYER_POTION.potion))
+		.secondaries(ImmutableSet.of(ItemID.CAVIAR))
+		.ids(ImmutableSet.of(ItemID.PRAYER_MIX1, ItemID.PRAYER_MIX2))
+		.build()),
+
+	SUPERATTACK_MIX(Potion.builder()
+		.level(47)
+		.name("Superattack mix")
+		.complexBase(ImmutableSet.of(SUPER_ATTACK.potion))
+		.secondaries(ImmutableSet.of(ItemID.CAVIAR))
+		.ids(ImmutableSet.of(ItemID.SUPERATTACK_MIX1, ItemID.SUPERATTACK_MIX2))
+		.build()),
+
+	ANTIPOISON_SUPERMIX(Potion.builder()
+		.level(51)
+		.name("Anti-poison supermix")
+		.complexBase(ImmutableSet.of(SUPERANTIPOISON.potion))
+		.secondaries(ImmutableSet.of(ItemID.CAVIAR))
+		.ids(ImmutableSet.of(ItemID.ANTIPOISON_SUPERMIX1, ItemID.ANTIPOISON_SUPERMIX2))
+		.build()),
+
+	FISHING_MIX(Potion.builder()
+		.level(53)
+		.name("Fishing mix")
+		.complexBase(ImmutableSet.of(FISHING_POTION.potion))
+		.secondaries(ImmutableSet.of(ItemID.CAVIAR))
+		.ids(ImmutableSet.of(ItemID.FISHING_MIX1, ItemID.FISHING_MIX2))
+		.build()),
+
+	SUPER_ENERGY_MIX(Potion.builder()
+		.level(56)
+		.name("Super energy mix")
+		.complexBase(ImmutableSet.of(SUPER_ENERGY.potion))
+		.secondaries(ImmutableSet.of(ItemID.CAVIAR))
+		.ids(ImmutableSet.of(ItemID.SUPER_ENERGY_MIX1, ItemID.SUPER_ENERGY_MIX2))
+		.build()),
+
+	HUNTING_MIX(Potion.builder()
+		.level(58)
+		.name("Hunting mix")
+		.complexBase(ImmutableSet.of(HUNTER_POTION.potion))
+		.secondaries(ImmutableSet.of(ItemID.CAVIAR))
+		.ids(ImmutableSet.of(ItemID.HUNTING_MIX1, ItemID.HUNTING_MIX2))
+		.build()),
+
+	SUPER_STR_MIX(Potion.builder()
+		.level(59)
+		.name("Super strength mix")
+		.complexBase(ImmutableSet.of(SUPER_STRENGTH.potion))
+		.secondaries(ImmutableSet.of(ItemID.CAVIAR))
+		.ids(ImmutableSet.of(ItemID.SUPER_STR_MIX1, ItemID.SUPER_STR_MIX2))
+		.build()),
+
+	MAGIC_ESSENCE_MIX(Potion.builder()
+		.level(61)
+		.name("Magic essence mix")
+		.complexBase(ImmutableSet.of(MAGIC_ESSENCE.potion))
+		.secondaries(ImmutableSet.of(ItemID.CAVIAR))
+		.ids(ImmutableSet.of(ItemID.MAGIC_ESSENCE_MIX1, ItemID.MAGIC_ESSENCE_MIX2))
+		.build()),
+
+	SUPER_RESTORE_MIX(Potion.builder()
+		.level(67)
+		.name("Super restore mix")
+		.complexBase(ImmutableSet.of(SUPER_RESTORE.potion))
+		.secondaries(ImmutableSet.of(ItemID.CAVIAR))
+		.ids(ImmutableSet.of(ItemID.SUPER_RESTORE_MIX1, ItemID.SUPER_RESTORE_MIX2))
+		.build()),
+
+	SUPER_DEF_MIX(Potion.builder()
+		.level(71)
+		.name("Super defence mix")
+		.complexBase(ImmutableSet.of(SUPER_DEFENCE.potion))
+		.secondaries(ImmutableSet.of(ItemID.CAVIAR))
+		.ids(ImmutableSet.of(ItemID.SUPER_DEF_MIX1, ItemID.SUPER_DEF_MIX2))
+		.build()),
+
+	ANTIDOTE_MIX(Potion.builder()
+		.level(74)
+		.name("Antidote+ mix")
+		.complexBase(ImmutableSet.of(ANTIDOTE_PLUS.potion))
+		.secondaries(ImmutableSet.of(ItemID.CAVIAR))
+		.ids(ImmutableSet.of(ItemID.ANTIDOTE_MIX1, ItemID.ANTIDOTE_MIX2))
+		.build()),
+
+	ANTIFIRE_MIX(Potion.builder()
+		.level(75)
+		.name("Antifire mix")
+		.complexBase(ImmutableSet.of(ANTIFIRE_POTION.potion))
+		.secondaries(ImmutableSet.of(ItemID.CAVIAR))
+		.ids(ImmutableSet.of(ItemID.ANTIFIRE_MIX1, ItemID.ANTIFIRE_MIX2))
+		.build()),
+
+	RANGING_MIX(Potion.builder()
+		.level(80)
+		.name("Ranging mix")
+		.complexBase(ImmutableSet.of(RANGING_POTION.potion))
+		.secondaries(ImmutableSet.of(ItemID.CAVIAR))
+		.ids(ImmutableSet.of(ItemID.RANGING_MIX1, ItemID.RANGING_MIX2))
+		.build()),
+
+	MAGIC_MIX(Potion.builder()
+		.level(83)
+		.name("Magic mix")
+		.complexBase(ImmutableSet.of(MAGIC_POTION.potion))
+		.secondaries(ImmutableSet.of(ItemID.CAVIAR))
+		.ids(ImmutableSet.of(ItemID.MAGIC_MIX1, ItemID.MAGIC_MIX2))
+		.build()),
+
+	ZAMORAK_MIX(Potion.builder()
+		.level(85)
+		.name("Zamorak mix")
+		.complexBase(ImmutableSet.of(ZAMORAK_BREW.potion))
+		.secondaries(ImmutableSet.of(ItemID.CAVIAR))
+		.ids(ImmutableSet.of(ItemID.ZAMORAK_MIX1, ItemID.ZAMORAK_MIX2))
+		.build()),
+
+	STAMINA_MIX(Potion.builder()
+		.level(86)
+		.name("Stamina mix")
+		.complexBase(ImmutableSet.of(STAMINA_POTION.potion))
+		.secondaries(ImmutableSet.of(ItemID.CAVIAR))
+		.ids(ImmutableSet.of(ItemID.STAMINA_MIX1, ItemID.STAMINA_MIX2))
+		.build()),
+
+	EXTENDED_ANTIFIRE_MIX(Potion.builder()
+		.level(91)
+		.name("Extended antifire mix")
+		.complexBase(ImmutableSet.of(EXTENDED_ANTIFIRE.potion))
+		.secondaries(ImmutableSet.of(ItemID.CAVIAR))
+		.ids(ImmutableSet.of(ItemID.EXTENDED_ANTIFIRE_MIX1, ItemID.EXTENDED_ANTIFIRE_MIX2))
+		.build()),
+
+	ANCIENT_MIX(Potion.builder()
+		.level(92)
+		.name("Ancient mix")
+		.complexBase(ImmutableSet.of(ANCIENT_BREW.potion))
+		.secondaries(ImmutableSet.of(ItemID.CAVIAR))
+		.ids(ImmutableSet.of(ItemID.ANCIENT_MIX1, ItemID.ANCIENT_MIX2))
+		.build()),
+
+	SUPER_ANTIFIRE_MIX(Potion.builder()
+		.level(98)
+		.name("Super antifire mix")
+		.complexBase(ImmutableSet.of(SUPER_ANTIFIRE_POTION.potion))
+		.secondaries(ImmutableSet.of(ItemID.CAVIAR))
+		.ids(ImmutableSet.of(ItemID.SUPER_ANTIFIRE_MIX1, ItemID.SUPER_ANTIFIRE_MIX2))
+		.build()),
+
+	EXTENDED_SUPER_ANTIFIRE_MIX(Potion.builder()
+		.level(99)
+		.name("Extended super antifire mix")
+		.complexBase(ImmutableSet.of(EXTENDED_SUPER_ANTIFIRE.potion))
+		.secondaries(ImmutableSet.of(ItemID.CAVIAR))
+		.ids(ImmutableSet.of(ItemID.EXTENDED_SUPER_ANTIFIRE_MIX1, ItemID.EXTENDED_SUPER_ANTIFIRE_MIX2))
 		.build());
 
 	private static final Map<Integer, List<Potion>> primaryToPotion = new HashMap<>();


### PR DESCRIPTION
## Summary
- **Fix tooltips not showing (#32):** RuneLite deprecated `ITEM_FIRST_OPTION` through `ITEM_FIFTH_OPTION` and `ITEM_USE` in favor of `WIDGET_FIRST_OPTION` through `WIDGET_FIFTH_OPTION`. The old constants are no longer returned at runtime, so the switch statement in `HerbloreRecipesOverlay.render()` never matched and tooltips never displayed. Also switched from container slot lookup to `menuEntry.getItemId()` and upgraded Gradle wrapper to 8.10.2 for JDK 21 compatibility.
- **Add 9 new potions:** Surge potion, haemostatic poultice, haemostatic dressing, super fishing potion, extreme energy potion, super hunter potion, extended stamina potion, armadyl brew, anti-odour salt.
- **Add all 29 barbarian mixes:** Attack mix through extended super antifire mix.

## Test plan
- [x] Verified tooltips appear on herbs, secondaries, unfinished potions, and potions in inventory and bank
- [x] Tested with keybind mode and always-on mode
- [x] Plugin builds cleanly with Gradle 8.10.2 and JDK 21